### PR TITLE
fix: improve thermal printer ticket unit legibility

### DIFF
--- a/ai/features/fix-thermal-printer-blurry-units/SPEC.md
+++ b/ai/features/fix-thermal-printer-blurry-units/SPEC.md
@@ -1,0 +1,129 @@
+# SPEC — Fix blurry units on thermal printer fallback ticket
+
+**Feature:** Improve legibility of unit/quantity text on the thermal printer HTML fallback ticket.
+**Scope:** CSS-only change in one function. No data-model changes. No new dependencies.
+
+---
+
+## 1. Problem
+
+The POS has two thermal printing paths:
+
+| Path | Mechanism | Triggered when |
+|------|-----------|----------------|
+| **QZ Tray (raw ESC/POS)** | `generateThermalReceipt()` → sends raw ESC/POS commands to the printer via qz-tray | `qzTrayEnabled = true` (default) |
+| **HTML fallback** | `buildThermalPrintHTML()` → opens a popup window with styled HTML, then calls `window.print()` | `qzTrayEnabled = false` (e.g. qz-tray unavailable or user toggled it off) |
+
+The **HTML fallback** ticket renders product quantities with this CSS (lines 240-246 and 268 of `BrowserPrint.ts`):
+
+```html
+<div class="product-price">x${p.amount} $${p.unitPrice.toFixed(2)}</div>
+```
+
+```css
+.product-price { font-size: 11px; color: #555; }
+```
+
+**Root cause:** On thermal printers (typically 203 DPI), small text (11px) combined with gray color (#555) produces blurry, hard-to-read output. The browser's font rendering antialiases the gray text against the white background, and the low DPI of the thermal head amplifies the blur.
+
+In contrast, the **QZ Tray (ESC/POS) path** uses raw printer commands with `BOLD_ON` (`\x1B\x45\x01`) for the quantity line, which renders natively on the printer with full contrast and no antialiasing — hence it looks sharp.
+
+---
+
+## 2. Goals
+
+- Make the `product-price` line (units × unit price) in the HTML fallback thermal ticket **bolder and slightly larger**.
+- Keep the change minimal and scoped to the CSS only — no structural HTML changes.
+- Ensure the total ticket width (80mm paper) is not broken by the size increase.
+
+## 3. Non-Goals (explicitly out of scope)
+
+- No changes to the QZ Tray / ESC/POS path (`generateThermalReceipt()`).
+- No changes to non-thermal print paths (PDF export, A4 browser print).
+- No changes to the `PrintableTable` React component or its data flow.
+- No new dependencies or configuration.
+
+---
+
+## 4. Design Overview
+
+### 4.1 Target file
+
+`src/lib/print/BrowserPrint.ts` — the `buildThermalPrintHTML()` function (lines 232-357).
+
+### 4.2 Change: CSS only
+
+Modify the `.product-price` CSS rule inside the `<style>` block of `buildThermalPrintHTML()`:
+
+**Before:**
+```css
+.product-price { font-size: 11px; color: #555; }
+```
+
+**After:**
+```css
+.product-price { font-size: 12px; font-weight: 700; color: #000; }
+```
+
+### 4.3 Rationale
+
+| Property | Before | After | Why |
+|----------|--------|-------|-----|
+| `font-size` | `11px` | `12px` | Slightly larger text renders clearer on 203 DPI thermal heads. 12px fits well within the 80mm (≈304px at 96 DPI) ticket width. |
+| `font-weight` | (not set / normal) | `700` (bold) | Bold text has thicker strokes, reducing the antialiasing blur effect on low-DPI printers. Matches the ESC/POS path which uses `BOLD_ON`. |
+| `color` | `#555` (gray) | `#000` (black) | Full-contrast black eliminates gray antialiasing artifacts. Thermal printers print in binary (black/white) anyway, so gray is always simulated via dithering which looks blurry. |
+
+### 4.4 Impact on layout
+
+The `product-price` div occupies the middle section of a flex row:
+```css
+.product-row { display: flex; flex-wrap: wrap; ... }
+.product-desc { width: 100%; ... }         /* Full width, above */
+.product-price { font-size: 12px; ... }    /* Left side of row below desc */
+.product-sum { font-weight: 700; font-size: 13px; }  /* Right side */
+```
+
+With `flex-wrap: wrap`, the `product-price` and `product-sum` share the row. A 1px increase (11→12px) is negligible and will not cause wrapping issues given the typical content length (`x2 $150.00` is ~14 chars at 12px ≈ 100px, well within the 80mm ticket).
+
+---
+
+## 5. Files & Changes
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/lib/print/BrowserPrint.ts` | In `buildThermalPrintHTML()`, update the `.product-price` CSS rule (line 268): `font-size: 11px; color: #555;` → `font-size: 12px; font-weight: 700; color: #000;` |
+
+### Unchanged files
+
+- `src/lib/print/BrowserPrint.ts` — `generateThermalReceipt()` (ESC/POS path) is untouched.
+- `src/components/Billing/PrintableTable.tsx` — no changes.
+- `src/components/Billing/BillButtons.tsx` — no changes.
+- `src/context/BillProvider.tsx`, `BillContext.tsx` — no changes.
+- `src/lib/print/PDFExport.ts` — no changes.
+
+---
+
+## 6. Acceptance Criteria (measurable)
+
+1. **CSS change only:** The only code modification is the `.product-price` CSS rule in `buildThermalPrintHTML()` — `font-size: 12px`, `font-weight: 700`, `color: #000`.
+2. **HTML fallback renders bold units:** When printing via HTML fallback (QZ Tray disabled), the quantity line (`x2 $150.00`) renders in **bold black text at 12px**.
+3. **QZ Tray path unaffected:** The ESC/POS receipt generated by `generateThermalReceipt()` is byte-for-byte identical before and after the change.
+4. **Layout preserved:** The product row (`product-desc` + `product-price` + `product-sum`) does not break or wrap unexpectedly for typical product descriptions (≤30 chars) and prices (≤10 chars).
+5. **No regressions:** `npm run lint` passes; `npm run build` succeeds.
+
+---
+
+## 7. Out of scope / open questions
+
+- Whether other text elements in the HTML fallback (e.g. `.info-row`, `.product-desc`) should also be adjusted for thermal legibility — can be a follow-up if needed.
+- Whether the `product-sum` (subtotal) should also receive `color: #000` for consistency — currently it already has `font-weight: 700` so it renders acceptably.
+
+---
+
+## 8. Definition of Done
+
+- The `.product-price` CSS rule in `buildThermalPrintHTML()` is updated to `font-size: 12px; font-weight: 700; color: #000;`.
+- Manual verification: print a test ticket via HTML fallback (QZ Tray off) and confirm units are bold, black, and legible on the thermal printer.
+- Lint and build pass with no errors.

--- a/ai/features/fix-thermal-printer-blurry-units/TEST_CHECKLIST.md
+++ b/ai/features/fix-thermal-printer-blurry-units/TEST_CHECKLIST.md
@@ -1,0 +1,92 @@
+# TEST_CHECKLIST.md — Fix blurry units on thermal printer ticket
+
+**Feature:** Fix blurry units on thermal printer ticket
+**Spec:** `ai/features/fix-thermal-printer-blurry-units/SPEC.md`
+**Test file:** `ai/features/fix-thermal-printer-blurry-units/thermal-printer-css.test.ts`
+
+---
+
+## Acceptance Criteria Checklist
+
+### AC1 — CSS change only
+
+| # | Check | Test | Status |
+|---|-------|------|--------|
+| 1.1 | `.product-price` rule exists in `buildThermalPrintHTML()` source | `should contain a .product-price CSS rule in the source` | ⬜ |
+| 1.2 | `font-size: 12px` (was 11px) | `should have font-size: 12px` | ⬜ |
+| 1.3 | `font-weight: 700` (was not set) | `should have font-weight: 700` | ⬜ |
+| 1.4 | `color: #000` (was #555) | `should have color: #000` | ⬜ |
+| 1.5 | Complete rule contains all three properties with correct values | `should contain the complete CSS rule: font-size: 12px; font-weight: 700; color: #000;` | ⬜ |
+| 1.6 | Old values (`font-size: 11px`, `color: #555`) are NOT present | Same test as 1.5 (uses `not.toContain`) | ⬜ |
+
+### AC2 — HTML fallback renders bold units
+
+| # | Check | Manual Verification | Status |
+|---|-------|---------------------|--------|
+| 2.1 | Quantity line renders in bold black text at 12px when QZ Tray is disabled | Print test ticket via HTML fallback (QZ Tray off) | ⬜ |
+| 2.2 | Text is legible on thermal printer (203 DPI) | Visual inspection on physical printer | ⬜ |
+
+### AC3 — QZ Tray path unaffected
+
+| # | Check | Manual Verification | Status |
+|---|-------|---------------------|--------|
+| 3.1 | `generateThermalReceipt()` output is identical before/after | Compare ESC/POS output byte-for-byte | ⬜ |
+| 3.2 | No changes to `ESCPOS` constants or `generateThermalReceipt()` function | Code review of `BrowserPrint.ts` | ⬜ |
+
+### AC4 — Layout preserved
+
+| # | Check | Test | Status |
+|---|-------|------|--------|
+| 4.1 | `.product-row` still uses `flex-wrap: wrap` | `should preserve flex-wrap: wrap on .product-row` | ⬜ |
+| 4.2 | `.product-desc` styling unchanged (font-size: 12.5px) | `should still have font-size: 12.5px on .product-desc` | ⬜ |
+| 4.3 | `.product-sum` styling unchanged (font-weight: 700, font-size: 13px) | `should not accidentally modify .product-sum styling` | ⬜ |
+| 4.4 | Product row does not break for typical content (≤30 chars desc, ≤10 chars price) | Manual verification on 80mm ticket | ⬜ |
+
+### AC5 — No regressions
+
+| # | Check | Command | Status |
+|---|-------|---------|--------|
+| 5.1 | `npm run lint` passes | Run `npm run lint` | ⬜ |
+| 5.2 | `npm run build` succeeds | Run `npm run build` | ⬜ |
+| 5.3 | All existing tests pass | Run `npm run test` | ⬜ |
+
+---
+
+## Edge Cases
+
+| # | Check | Status |
+|---|-------|--------|
+| EC1 | 12px fits within 80mm ticket width (~304px at 96 DPI) | ⬜ |
+| EC2 | Bold text does not cause horizontal overflow with `flex-wrap: wrap` | ⬜ |
+| EC3 | Typical product line `x2 $150.00` (~14 chars) renders at ~100px at 12px, well within 304px | ⬜ |
+
+---
+
+## Files Modified
+
+| File | Change | Verified |
+|------|--------|----------|
+| `src/lib/print/BrowserPrint.ts` | `.product-price` CSS rule updated (line ~268) | ⬜ |
+
+## Files NOT Modified (regression check)
+
+| File | Verified |
+|------|----------|
+| `src/lib/print/BrowserPrint.ts` — `generateThermalReceipt()` | ⬜ |
+| `src/components/Billing/PrintableTable.tsx` | ⬜ |
+| `src/components/Billing/BillButtons.tsx` | ⬜ |
+| `src/context/BillProvider.tsx` | ⬜ |
+| `src/lib/print/PDFExport.ts` | ⬜ |
+
+---
+
+## Test Execution
+
+Run the TDD tests:
+
+```bash
+npm run test -- ai/features/fix-thermal-printer-blurry-units/thermal-printer-css.test.ts
+```
+
+**Expected result BEFORE fix:** 4 tests FAIL (font-size, font-weight, color, full rule check)
+**Expected result AFTER fix:** All tests PASS

--- a/ai/features/fix-thermal-printer-blurry-units/thermal-printer-css.test.ts
+++ b/ai/features/fix-thermal-printer-blurry-units/thermal-printer-css.test.ts
@@ -1,0 +1,157 @@
+/**
+ * thermal-printer-css.test.ts
+ *
+ * TDD tests for the "Fix blurry units on thermal printer ticket" feature.
+ *
+ * These tests verify that the `.product-price` CSS rule inside
+ * `buildThermalPrintHTML()` in `src/lib/print/BrowserPrint.ts` has the correct
+ * properties for thermal printer legibility:
+ *   - font-size: 12px  (currently 11px → FAIL)
+ *   - font-weight: 700 (currently not set → FAIL)
+ *   - color: #000      (currently #555 → FAIL)
+ *
+ * The tests read the source file as text and extract the CSS rule directly,
+ * since `buildThermalPrintHTML` is not exported.
+ *
+ * @see ai/features/fix-thermal-printer-blurry-units/SPEC.md
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+// ── Source file path ─────────────────────────────────────────────────────────
+const SOURCE_FILE = resolve(
+  __dirname,
+  "../../../src/lib/print/BrowserPrint.ts"
+);
+
+// ── Read source once for all tests ──────────────────────────────────────────
+let sourceCode: string;
+
+beforeAll(() => {
+  sourceCode = readFileSync(SOURCE_FILE, "utf-8");
+});
+
+// ── Helper: extract the .product-price CSS rule from the source ──────────────
+function extractProductPriceCSS(src: string): string | null {
+  // Match the .product-price CSS rule inside the <style> block.
+  // The rule may span one line:  .product-price { font-size: 11px; color: #555; }
+  const regex = /\.product-price\s*\{([^}]+)\}/;
+  const match = src.match(regex);
+  return match ? match[1].trim() : null;
+}
+
+// ── Helper: extract a single CSS property value from a rule body ─────────────
+function getCSSProperty(
+  ruleBody: string,
+  property: string
+): string | null {
+  // Match `property: value;` — value may contain #, px, numbers, etc.
+  const regex = new RegExp(`${property}\\s*:\\s*([^;]+)\\s*;?`);
+  const match = ruleBody.match(regex);
+  return match ? match[1].trim() : null;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST SUITE
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("Thermal printer CSS — .product-price rule", () => {
+  describe("AC1: CSS rule exists in buildThermalPrintHTML()", () => {
+    it("should contain a .product-price CSS rule in the source", () => {
+      const ruleBody = extractProductPriceCSS(sourceCode);
+      expect(ruleBody).not.toBeNull();
+    });
+  });
+
+  describe("AC1: font-size is 12px (not 11px)", () => {
+    it("should have font-size: 12px — RED test (currently 11px)", () => {
+      const ruleBody = extractProductPriceCSS(sourceCode);
+      expect(ruleBody).not.toBeNull();
+
+      const fontSize = getCSSProperty(ruleBody!, "font-size");
+
+      // The current code has font-size: 11px — this assertion will FAIL until
+      // the developer changes it to 12px.
+      expect(fontSize).toBe("12px");
+    });
+  });
+
+  describe("AC1: font-weight is 700 (bold)", () => {
+    it("should have font-weight: 700 — RED test (currently not set)", () => {
+      const ruleBody = extractProductPriceCSS(sourceCode);
+      expect(ruleBody).not.toBeNull();
+
+      const fontWeight = getCSSProperty(ruleBody!, "font-weight");
+
+      // The current code does NOT set font-weight, so this will be null.
+      // After the fix, it should be "700".
+      expect(fontWeight).toBe("700");
+    });
+  });
+
+  describe("AC1: color is #000 (black, not #555 gray)", () => {
+    it("should have color: #000 — RED test (currently #555)", () => {
+      const ruleBody = extractProductPriceCSS(sourceCode);
+      expect(ruleBody).not.toBeNull();
+
+      const color = getCSSProperty(ruleBody!, "color");
+
+      // The current code has color: #555 — this assertion will FAIL until
+      // the developer changes it to #000.
+      expect(color).toBe("#000");
+    });
+  });
+
+  describe("Full rule verification (combined check)", () => {
+    it("should contain the complete CSS rule: font-size: 12px; font-weight: 700; color: #000;", () => {
+      const ruleBody = extractProductPriceCSS(sourceCode);
+      expect(ruleBody).not.toBeNull();
+
+      // Verify all three properties exist in the rule body with correct values.
+      // This is a comprehensive check that the entire rule was updated.
+      expect(ruleBody).toContain("font-size: 12px");
+      expect(ruleBody).toContain("font-weight: 700");
+      expect(ruleBody).toContain("color: #000");
+
+      // Ensure old values are NOT present
+      expect(ruleBody).not.toContain("font-size: 11px");
+      expect(ruleBody).not.toContain("color: #555");
+    });
+  });
+
+  describe("AC4: Layout — product-row uses flex-wrap (no breaking change)", () => {
+    it("should preserve flex-wrap: wrap on .product-row", () => {
+      const regex = /\.product-row\s*\{([^}]+)\}/;
+      const match = sourceCode.match(regex);
+      expect(match).not.toBeNull();
+
+      const ruleBody = match![1];
+      expect(ruleBody).toContain("flex-wrap: wrap");
+    });
+  });
+
+  describe("Regression: product-sum retains font-weight: 700", () => {
+    it("should not accidentally modify .product-sum styling", () => {
+      const regex = /\.product-sum\s*\{([^}]+)\}/;
+      const match = sourceCode.match(regex);
+      expect(match).not.toBeNull();
+
+      const ruleBody = match![1];
+      expect(ruleBody).toContain("font-weight: 700");
+      expect(ruleBody).toContain("font-size: 13px");
+    });
+  });
+
+  describe("Regression: only .product-price CSS is changed (no other rules modified)", () => {
+    it("should still have font-size: 12.5px on .product-desc", () => {
+      const regex = /\.product-desc\s*\{([^}]+)\}/;
+      const match = sourceCode.match(regex);
+      expect(match).not.toBeNull();
+
+      const ruleBody = match![1];
+      expect(ruleBody).toContain("font-size: 12.5px");
+    });
+  });
+});

--- a/src/lib/print/BrowserPrint.ts
+++ b/src/lib/print/BrowserPrint.ts
@@ -265,7 +265,7 @@ function buildThermalPrintHTML(data: ThermalReceiptData, qrDataUrl: string | nul
       .products { width: 100%; margin-bottom: 3mm; }
       .product-row { display: flex; flex-wrap: wrap; margin-bottom: 2mm; justify-content: space-between; align-items: flex-end; }
       .product-desc { width: 100%; font-weight: 600; font-size: 12.5px; }
-      .product-price { font-size: 11px; color: #555; }
+      .product-price { font-size: 12px; font-weight: 700; color: #000; }
       .product-sum { font-weight: 700; font-size: 13px; }
       .totals { border-top: 2px dashed #ccc; padding-top: 3mm; margin-top: 3mm; }
       .total-row { display: flex; justify-content: space-between; font-size: 13px; margin-bottom: 1mm; }


### PR DESCRIPTION
- Change .product-price CSS in buildThermalPrintHTML():
  - font-size: 11px → 12px (slightly larger for better DPI rendering)
  - font-weight: normal → 700 (bold for sharper strokes)
  - color: #555 → #000 (full black for maximum contrast)

This fixes blurry units on thermal printer fallback tickets (HTML path) while keeping the QZ Tray ESC/POS path unaffected.

Tests: 8/8 passing
Lint: No new errors
TypeCheck: No new errors